### PR TITLE
First attempt to cache PLT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,18 +5,32 @@ on: push
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    name: OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }}
     strategy:
       matrix:
         otp: [22.0.7, 22.1.8.1, 22.2.3]
         elixir: [1.9.4]
     steps:
       - uses: actions/checkout@v2
+        name: Checkout
+
+      - uses: actions/cache@v1
+        name: Cache PLT
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
+
       - uses: actions/setup-elixir@v1
+        name: Setup elixir
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+
       - run: mix deps.get
+      - run: mix deps.compile --force
+      - run: mix compile --force
       - run: mix test --trace
       - run: mix credo
       - run: mix dialyzer


### PR DESCRIPTION
Adds a cache of the entire _build dir to save PLT for next build.

Uses Elixir and Erlang versions as part of the cache key, since we want to rebuild PLT if they change.