### PR TITLE
Project migration

### DIFF
--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -242,6 +242,21 @@ defmodule Quantity do
   end
 
   @doc """
+  Compares two quantities with the same unit numerically
+
+  iex> Quantity.compare(~Q[1.00 m], ~Q[2.00 m])
+  :lt
+  iex> Quantity.compare(~Q[1.00 m], ~Q[1 m])
+  :eq
+  iex> Quantity.compare(~Q[3.00 m], ~Q[2.9999999 m])
+  :gt
+  """
+  @spec compare(t, t) :: :lt | :eq | :gt
+  def compare(%{unit: unit} = q1, %{unit: unit} = q2) do
+    Decimal.cmp(q1.value, q2.value)
+  end
+
+  @doc """
   Extracts the base value from the quantity
   """
   @spec base_value(t) :: integer

--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -184,6 +184,31 @@ defmodule Quantity do
   def positive?(%{value: value}), do: Decimal.positive?(value)
 
   @doc """
+  Returns true if the two quantities are numerically equal
+
+  iex> Quantity.equals?(~Q[5 bananas], ~Q[5.0 bananas])
+  true
+
+  iex> Quantity.equals?(~Q[5 bananas], ~Q[5 apples])
+  false
+  """
+  @spec equals?(t, t) :: boolean
+  def equals?(q1, q2) do
+    reduce(q1) == reduce(q2)
+  end
+
+  @doc """
+  Reduces the value to the largest possible exponent without altering the numerical value
+
+  iex> Quantity.reduce(~Q[1.200 m])
+  ~Q[1.2 m]
+  """
+  @spec reduce(t) :: t
+  def reduce(quantity) do
+    %{quantity | value: Decimal.reduce(quantity.value)}
+  end
+
+  @doc """
   Return a quantity with a zero value and the same unit and precision as another Quantity
 
   iex> ~Q[123.99 EUR] |> Quantity.to_zero()

--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -199,6 +199,24 @@ defmodule Quantity do
   def to_zero(%{unit: unit, value: %Decimal{exp: exp}}), do: Quantity.new(0, exp, unit)
 
   @doc """
+  Converts the quantity to have a new unit.
+  The new unit must be a whole 10-exponent more or less than the original unit.
+
+  The exponent given is the difference in exponents (new-exponent - old-exponent).
+  For example when converting from kWh to MWh: 6 (MWh) - 3 (kWh) = 3
+
+  iex> ~Q[1234E3 Wh] |> Quantity.convert_unit("MWh", 6)
+  ~Q[1.234 MWh]
+
+  iex> ~Q[25.2 m] |> Quantity.convert_unit("mm", -3)
+  ~Q[252E2 mm]
+  """
+  @spec convert_unit(t, String.t(), integer) :: t
+  def convert_unit(quantity, new_unit, exponent) do
+    new(Decimal.new(quantity.value.sign, quantity.value.coef, quantity.value.exp - exponent), new_unit)
+  end
+
+  @doc """
   Extracts the base value from the quantity
   """
   @spec base_value(t) :: integer

--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -107,12 +107,7 @@ defmodule Quantity do
   """
   @spec to_string(t) :: String.t()
   def to_string(quantity) do
-    decimal_string =
-      if quantity.value.exp > 0 do
-        Decimal.to_string(quantity.value, :raw)
-      else
-        Decimal.to_string(quantity.value, :normal)
-      end
+    decimal_string = decimal_to_string(quantity.value)
 
     unit_string =
       case quantity.unit do
@@ -122,6 +117,25 @@ defmodule Quantity do
       end
 
     "#{decimal_string} #{unit_string}"
+  end
+
+  @doc """
+  Encodes a decimal as string. Uses either :raw (E-notation) or :normal based on exponent, so that precision is not
+  lost
+
+  iex> Quantity.decimal_to_string(~d[1.234])
+  "1.234"
+
+  iex> Quantity.decimal_to_string(~d[1E3])
+  "1E3"
+  """
+  @spec decimal_to_string(Decimal.t()) :: String.t()
+  def decimal_to_string(%Decimal{} = decimal) do
+    if decimal.exp > 0 do
+      Decimal.to_string(decimal, :raw)
+    else
+      Decimal.to_string(decimal, :normal)
+    end
   end
 
   @doc """


### PR DESCRIPTION
After migrating another project to use Quantity, this is the functionality that was needed.

Most notable is `compare/2` which is only implemented for same unit quantities. We should consider being able to compare different units for use with Elixir sort functions. Or perhaps have one function for comparing same-unit (and fail on different units) and another, `compare/2`, for sorting.