### PR TITLE
Feature proposal: Add Quantity.inverse/1 and new 1/unit type of unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ Quantity.parse!("15.0 m*m")
 # Quantity.new(~d[15.0], {:mult, "m", "m"})
 ```
 
+Note: When complex units are used, the parse function allows for :div and :mult of the form `a*b*c/d*e*f`, which
+mathematically is interpretted as (a*b*c)/(d*e*f).
+
+```elixir
+~Q[1 a*b*c/d*e*f].unit
+# {:div, {:mult, "a", {:mult, "b", "c"}}, {:mult, "d", {:mult, "e", "f"}}}
+```
+
+Quantity supports unit-less quantities, which acts as decimals. Technically they have the unit `1`
+~Q[42].unit
+# 1
+
 The `Quantity` module also has `new/2` which creates a `Quantity` from a `Decimal.t()` and a `String.t()`:
 
 ```elixir
@@ -117,13 +129,16 @@ sales_2019 |> Quantity.sum(-2, "EUR")
 
 #### Multiplication and division
 
-Quantity has support for single-level complex units that are divided or multiplied:
+Quantity has support for arbitrary complex units with :div and :mult
 
 ```elixir
 cost = ~Q[20.00 $]
 amount = ~Q[50 banana]
 cost_per_banana = Quantity.div(cost, amount)
 # ~Q[0.40 $/banana]
+
+Quantity.div(~Q[50 bananas], ~Q[5 bananas])
+# ~Q[10]
 
 new_amount = ~Q[2000 banana]
 Quantity.mult(cost_per_banana, new_amount)
@@ -134,6 +149,9 @@ Quantity.mult(~Q[5 m], ~Q[4.3 m])
 
 Quantity.mult(~Q[5 m], ~d[20.01])
 # ~Q[100.05 m]
+
+Quantity.mult(~Q[10 m/s*s], ~Q[5 s])
+# ~Q[50 m/s]
 ```
 
 #### The ~Q and ~d sigils

--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -10,7 +10,7 @@ defmodule Quantity do
           unit: unit
         }
 
-  @type unit :: String.t() | {:div | :mult, String.t(), String.t()}
+  @type unit :: String.t() | {:mult, String.t(), String.t()} | {:div, String.t() | nil, String.t()}
 
   defstruct [
     :value,
@@ -20,6 +20,7 @@ defmodule Quantity do
   defdelegate add!(quantity_1, quantity_2), to: Math
   defdelegate add(quantity_1, quantity_2), to: Math
   defdelegate div(dividend, divisor), to: Math
+  defdelegate inverse(quantity), to: Math
   defdelegate mult(quantity, quantity_or_scalar), to: Math
   defdelegate round(quantity, decimals), to: Math
   defdelegate sub!(quantity_1, quantity_2), to: Math
@@ -72,6 +73,7 @@ defmodule Quantity do
          {:ok, value} <- Decimal.parse(value_string) do
       unit =
         cond do
+          unit_string =~ ~r[^1/] -> {:div, nil, String.slice(unit_string, 2..-1)}
           unit_string =~ "/" -> [:div | String.split(unit_string, "/", parts: 2)] |> List.to_tuple()
           unit_string =~ "*" -> [:mult | String.split(unit_string, "*", parts: 2)] |> List.to_tuple()
           true -> unit_string
@@ -111,6 +113,7 @@ defmodule Quantity do
 
     unit_string =
       case quantity.unit do
+        {:div, nil, unit} -> "1/#{unit}"
         {:div, u1, u2} -> "#{u1}/#{u2}"
         {:mult, u1, u2} -> "#{u1}*#{u2}"
         unit -> unit

--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -292,6 +292,15 @@ defmodule Quantity do
   def exponent(quantity), do: quantity.value.exp
 
   @doc """
+  Converts a 1-unit quantity to a decimal. If the quantity does not represent a decimal (a unit other than 1) it fails.
+
+  iex> Quantity.to_decimal!(~Q[42])
+  ~d[42]
+  """
+  @spec to_decimal!(t) :: Decimal.t()
+  def to_decimal!(%{unit: 1} = quantity), do: quantity.value
+
+  @doc """
   Extracts the unit from the quantity
   """
   @spec unit(t) :: unit

--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -132,13 +132,14 @@ defmodule Quantity do
 
     unit_string =
       case quantity.unit do
-        {:div, nil, unit} -> "1/#{unit}"
-        {:div, u1, u2} -> "#{u1}/#{u2}"
-        {:mult, u1, u2} -> "#{u1}*#{u2}"
-        unit -> unit
+        1 -> ""
+        {:div, nil, unit} -> " 1/#{unit}"
+        {:div, u1, u2} -> " #{u1}/#{u2}"
+        {:mult, u1, u2} -> " #{u1}*#{u2}"
+        unit when is_binary(unit) -> " #{unit}"
       end
 
-    "#{decimal_string} #{unit_string}"
+    "#{decimal_string}#{unit_string}"
   end
 
   @doc """

--- a/lib/quantity/math.ex
+++ b/lib/quantity/math.ex
@@ -182,6 +182,25 @@ defmodule Quantity.Math do
   end
 
   @doc """
+  Inverse a Quantity, similar to 1/quantity
+
+  iex> Quantity.inverse(~Q[10 DKK/m³])
+  ~Q[0.1 m³/DKK]
+  """
+  @spec inverse(Quantity.t()) :: Quantity.t()
+  def inverse(%Quantity{unit: {:div, nil, unit}} = quantity) do
+    Quantity.new(Decimal.div(1, quantity.value), unit)
+  end
+
+  def inverse(%Quantity{unit: {:div, unit_a, unit_b}} = quantity) do
+    Quantity.new(Decimal.div(1, quantity.value), {:div, unit_b, unit_a})
+  end
+
+  def inverse(quantity) do
+    Quantity.new(Decimal.div(1, quantity.value), {:div, nil, quantity.unit})
+  end
+
+  @doc """
   Multiply a quantity by a scalar or another quantity
 
   iex> Quantity.mult(~Q[15 $], ~d[4])

--- a/test/math_test.exs
+++ b/test/math_test.exs
@@ -58,4 +58,38 @@ defmodule Quantity.MathTest do
                ~Q[0.1 banana]
     end
   end
+
+  describe "div" do
+    test "dividing by quantity without unit" do
+      assert Quantity.div(~Q[25 bananas], ~Q[5]) == ~Q[5 bananas]
+    end
+
+    test "dividing by 1/unit" do
+      assert Quantity.div(~Q[25 bananas], ~Q[5 1/s]) == ~Q[5 bananas*s]
+    end
+
+    test "dividing 1 unit with regular quantity" do
+      assert Quantity.div(~Q[25], ~Q[5 bananas]) == ~Q[5 1/bananas]
+    end
+  end
+
+  describe "mult" do
+    test "mutliplying by quantity without unit" do
+      assert Quantity.mult(~Q[12 bananas], ~Q[3]) == ~Q[36 bananas]
+    end
+
+    test "mutliplying by quantity with 1/unit" do
+      assert Quantity.mult(~Q[12 bananas], ~Q[3 1/s]) == ~Q[36 bananas/s]
+    end
+
+    test "mutliplying by quantity with 1/unit that matches" do
+      assert Quantity.mult(~Q[12 s], ~Q[3 1/s]) == ~Q[36]
+      assert Quantity.mult(~Q[12 s*s], ~Q[3 1/s]) == ~Q[36 s]
+      assert Quantity.mult(~Q[12 s/banana], ~Q[3 1/s]) == ~Q[36 1/banana]
+    end
+
+    test "multiplying with inverse unit" do
+      assert Quantity.mult(~Q[12 s/banana], ~Q[3 banana/s]) == ~Q[36]
+    end
+  end
 end

--- a/test/math_test.exs
+++ b/test/math_test.exs
@@ -91,5 +91,10 @@ defmodule Quantity.MathTest do
     test "multiplying with inverse unit" do
       assert Quantity.mult(~Q[12 s/banana], ~Q[3 banana/s]) == ~Q[36]
     end
+
+    test "when unit does not produce anything valid, it still returns something" do
+      result = Quantity.mult(~Q[12 apples/s], ~Q[3 bananas/s])
+      assert result.unit == {:div, {:mult, "bananas", "apples"}, {:mult, "s", "s"}}
+    end
   end
 end

--- a/test/math_test.exs
+++ b/test/math_test.exs
@@ -74,15 +74,15 @@ defmodule Quantity.MathTest do
   end
 
   describe "mult" do
-    test "mutliplying by quantity without unit" do
+    test "multiplying by quantity without unit" do
       assert Quantity.mult(~Q[12 bananas], ~Q[3]) == ~Q[36 bananas]
     end
 
-    test "mutliplying by quantity with 1/unit" do
+    test "multiplying by quantity with 1/unit" do
       assert Quantity.mult(~Q[12 bananas], ~Q[3 1/s]) == ~Q[36 bananas/s]
     end
 
-    test "mutliplying by quantity with 1/unit that matches" do
+    test "multiplying by quantity with 1/unit that matches" do
       assert Quantity.mult(~Q[12 s], ~Q[3 1/s]) == ~Q[36]
       assert Quantity.mult(~Q[12 s*s], ~Q[3 1/s]) == ~Q[36 s]
       assert Quantity.mult(~Q[12 s/banana], ~Q[3 1/s]) == ~Q[36 1/banana]
@@ -92,9 +92,32 @@ defmodule Quantity.MathTest do
       assert Quantity.mult(~Q[12 s/banana], ~Q[3 banana/s]) == ~Q[36]
     end
 
-    test "when unit does not produce anything valid, it still returns something" do
-      result = Quantity.mult(~Q[12 apples/s], ~Q[3 bananas/s])
-      assert result.unit == {:div, {:mult, "bananas", "apples"}, {:mult, "s", "s"}}
+    test "multiplying to complex result" do
+      assert Quantity.mult(~Q[12 apples/s], ~Q[3 bananas/s]) == ~Q[36 apples*bananas/s*s]
     end
+  end
+
+  test "complex units" do
+    amount = ~Q[5000 banana]
+    rate = ~Q[5 banana/s]
+    rent = ~Q[0.50 USD/s]
+    earnings = ~Q[20 USD/hour]
+    work_time = ~Q[37 hour/week]
+
+    # Order doesn't matter
+    assert amount
+           |> Quantity.div(rate)
+           |> Quantity.mult(rent)
+           |> Quantity.div(earnings)
+           |> Quantity.div(work_time)
+           |> Quantity.round(2) == ~Q[0.68 week]
+
+    assert amount
+           |> Quantity.mult(rent)
+           # This will be in the unit "USD*banana*week/hour*s" :)
+           |> Quantity.div(work_time)
+           |> Quantity.div(rate)
+           |> Quantity.div(earnings)
+           |> Quantity.round(2) == ~Q[0.68 week]
   end
 end

--- a/test/math_test.exs
+++ b/test/math_test.exs
@@ -35,4 +35,27 @@ defmodule Quantity.MathTest do
       assert_raise(ArgumentError, fn -> Quantity.sum!([~Q[123 bananas], ~Q[456 apples]], 0, "apples") end)
     end
   end
+
+  describe "inverse" do
+    test "inverse of a quantity with simple unit" do
+      assert Quantity.inverse(~Q[10 banana]) == ~Q[0.1 1/banana]
+    end
+
+    test "inverse of a quantity with 1/unit" do
+      assert Quantity.inverse(~Q[0.1 1/banana]) == ~Q[1E1 banana]
+    end
+
+    test "inverse of a quantity with div unit" do
+      assert Quantity.inverse(~Q[10 banana/hour]) == ~Q[0.1 hour/banana]
+    end
+
+    test "using 1/unit quantities in other Math functions" do
+      assert ~Q[10 banana]
+             |> Quantity.inverse()
+             |> Quantity.mult(~d[50])
+             |> Quantity.add!(~Q[5 1/banana])
+             |> Quantity.inverse() ==
+               ~Q[0.1 banana]
+    end
+  end
 end

--- a/test/quantity_test.exs
+++ b/test/quantity_test.exs
@@ -9,7 +9,8 @@ defmodule QuantityTest do
       ~Q[0 units],
       ~Q[5 super powers],
       ~Q[42E1 wh],
-      ~Q[10 1/s]
+      ~Q[10 1/s],
+      ~Q[10]
     ]
 
     Enum.each(examples, fn quantity ->
@@ -21,9 +22,14 @@ defmodule QuantityTest do
     end)
   end
 
+  test "parsing with 1 unit" do
+    assert {:ok, quantity} = Quantity.parse("42")
+    assert quantity.unit == 1
+  end
+
   test "parsing 1/unit units" do
     assert {:ok, quantity} = Quantity.parse("1 1/unit")
-    assert quantity.unit == {:div, nil, "unit"}
+    assert quantity.unit == {:div, 1, "unit"}
   end
 
   test "inspecting" do

--- a/test/quantity_test.exs
+++ b/test/quantity_test.exs
@@ -39,4 +39,8 @@ defmodule QuantityTest do
   test "text interpolating" do
     assert "#{~Q[12.45 DKK]}" == "12.45 DKK"
   end
+
+  test "to_string for 1-unit" do
+    assert Quantity.to_string(~Q[42]) == "42"
+  end
 end

--- a/test/quantity_test.exs
+++ b/test/quantity_test.exs
@@ -8,7 +8,8 @@ defmodule QuantityTest do
       ~Q[65465465465465464.64654654654654654 kw/h],
       ~Q[0 units],
       ~Q[5 super powers],
-      ~Q[42E1 wh]
+      ~Q[42E1 wh],
+      ~Q[10 1/s]
     ]
 
     Enum.each(examples, fn quantity ->
@@ -18,6 +19,11 @@ defmodule QuantityTest do
       assert is_binary(encoded)
       assert parsed == quantity
     end)
+  end
+
+  test "parsing 1/unit units" do
+    assert {:ok, quantity} = Quantity.parse("1 1/unit")
+    assert quantity.unit == {:div, nil, "unit"}
   end
 
   test "inspecting" do

--- a/test/quantity_test.exs
+++ b/test/quantity_test.exs
@@ -4,21 +4,22 @@ defmodule QuantityTest do
 
   test "parsing and encoding" do
     examples = [
-      ~Q[12.45 DKK],
-      ~Q[65465465465465464.64654654654654654 kw/h],
-      ~Q[0 units],
-      ~Q[5 super powers],
-      ~Q[42E1 wh],
-      ~Q[10 1/s],
-      ~Q[10]
+      "12.45 DKK",
+      "65465465465465464.64654654654654654 kw/h",
+      "0 units",
+      "5 super powers",
+      "42E1 wh",
+      "10 1/s",
+      "10",
+      "1 a*b*c/d*e*f",
+      "1 a*b"
     ]
 
-    Enum.each(examples, fn quantity ->
-      encoded = Quantity.to_string(quantity)
-      {:ok, parsed} = Quantity.parse(encoded)
+    Enum.each(examples, fn input ->
+      {:ok, parsed} = Quantity.parse(input)
+      encoded = Quantity.to_string(parsed)
 
-      assert is_binary(encoded)
-      assert parsed == quantity
+      assert encoded == input
     end)
   end
 
@@ -30,6 +31,12 @@ defmodule QuantityTest do
   test "parsing 1/unit units" do
     assert {:ok, quantity} = Quantity.parse("1 1/unit")
     assert quantity.unit == {:div, 1, "unit"}
+  end
+
+  test "complex unit" do
+    assert {:ok, quantity} = Quantity.parse("1 a*b*c/d*e*f")
+    assert quantity.unit == {:div, {:mult, "a", {:mult, "b", "c"}}, {:mult, "d", {:mult, "e", "f"}}}
+    assert Quantity.to_string(quantity) == "1 a*b*c/d*e*f"
   end
 
   test "inspecting" do


### PR DESCRIPTION
This is a handy feature allowing to calculate the inverse of a quantity. (1 / quantity)

It also introduces a new type of unit, `{:div, nil, String.t()}`, which makes sense in many use-cases, e.g. for frequencies where `Hz` == `1/sec` or for intermediate calculations/

E.g. `~Q[1 1/sec]` is interpreted as `value: 1, unit: {:div, nil, sec}`

The `inverse/1` function is also handy when we already have a `:div` unit in which case, the unit is just turned upside down.

@skovmand What do you think?