### PR TITLE
Fix type of unit to be recursive

### DIFF
--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -10,8 +10,8 @@ defmodule Quantity do
           unit: unit
         }
 
+  @type unit :: base_unit | {:div | :mult, unit, unit}
   @type base_unit :: String.t() | 1
-  @type unit :: base_unit | {:div | :mult, base_unit, base_unit}
 
   defstruct [
     :value,


### PR DESCRIPTION
Apparently Erlang has supported recursive type definitions since 2010 (ref: http://erlang.org/download/otp_src_R13B04.readme). I didn't know that, which is why the types were defined the way they were.

This gave a dialyzer error in a project using Quantity.