### PR TITLE
Update decimal 1.9.0 -> 2.0.0

### DIFF
--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -73,7 +73,7 @@ defmodule Quantity do
   @spec parse(String.t()) :: {:ok, t} | :error
   def parse(input) do
     with {:ok, value_string, unit_string} <- parse_split_value_and_unit(input),
-         {:ok, value} <- Decimal.parse(value_string) do
+         {value, ""} <- Decimal.parse(value_string) do
       unit = parse_unit(unit_string)
 
       {:ok, new(value, unit)}
@@ -282,7 +282,7 @@ defmodule Quantity do
   """
   @spec compare(t, t) :: :lt | :eq | :gt
   def compare(%{unit: unit} = q1, %{unit: unit} = q2) do
-    Decimal.cmp(q1.value, q2.value)
+    Decimal.compare(q1.value, q2.value)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Quantity.MixProject do
   defp deps do
     [
       # Decimal
-      {:decimal, "~> 1.9"},
+      {:decimal, "~> 2.0"},
 
       # Documentation
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
   "credo": {:hex, :credo, "1.4.0", "92339d4cbadd1e88b5ee43d427b639b68a11071b6f73854e33638e30a0ea11f5", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "1fd3b70dce216574ce3c18bdf510b57e7c4c85c2ec9cad4bff854abaf7e58658"},
-  "decimal": {:hex, :decimal, "1.9.0", "83e8daf59631d632b171faabafb4a9f4242c514b0a06ba3df493951c08f64d07", [:mix], [], "hexpm", "b1f2343568eed6928f3e751cf2dffde95bfaa19dd95d09e8a9ea92ccfd6f7d85"},
+  "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "earmark": {:hex, :earmark, "1.4.10", "bddce5e8ea37712a5bfb01541be8ba57d3b171d3fa4f80a0be9bcf1db417bcaf", [:mix], [{:earmark_parser, ">= 1.4.10", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "12dbfa80810478e521d3ffb941ad9fbfcbbd7debe94e1341b4c4a1b2411c1c27"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},


### PR DESCRIPTION
Closes #30 

This updates Decimal to 2.0.0, which contains some breaking changes.

I don't think this needs a major release of Quantity, since any app requiring Decimal `< 2.0.0` will just not be able to update to newest Quantity.