### PR TITLE
quantity/math: Add clarifying example about unit in sum/3

### DIFF
--- a/lib/quantity/math.ex
+++ b/lib/quantity/math.ex
@@ -116,6 +116,9 @@ defmodule Quantity.Math do
   iex> sum([], -2, "DKK")
   {:ok, ~Q[0.00 DKK]}
 
+  iex> sum([~Q[1 EUR], ~Q[2 EUR]], -1, "DKK")
+  {:ok, ~Q[3 EUR]}
+
   iex> sum([~Q[1 EUR], ~Q[2 DKK]], -2, "EUR")
   :error
   """
@@ -148,6 +151,9 @@ defmodule Quantity.Math do
 
   iex> sum!([], -2, "DKK")
   ~Q[0.00 DKK]
+
+  iex> sum!([~Q[1 apples], ~Q[2 apples]], -2, "pears")
+  ~Q[3 apples]
   """
   @spec sum!([Quantity.t()], integer, String.t()) :: Quantity.t()
   def sum!(quantities, exp, unit) do


### PR DESCRIPTION
There is a general problem when summing over an empty list.
The reason stems from that the unit is unknown if the list is empty.

sum/3 will therefore let you specify a precision and unit so that
sum/3 can return a "zero" with a unit.

This commit adds examples about what is the expected result if there
is a mismatch between the type in the list and the fallback unit.