### PR TITLE
Handle non numbers

### DIFF
--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -37,12 +37,21 @@ defmodule Quantity do
   """
   @spec new(Decimal.t(), unit) :: t
   def new(value, unit) do
-    unit = normalize_unit(unit)
+    cond do
+      Decimal.inf?(value) ->
+        raise ArgumentError, "Infinity not supported by Quantity"
 
-    %__MODULE__{
-      value: value,
-      unit: unit
-    }
+      Decimal.nan?(value) ->
+        raise ArgumentError, "NaN not supported by quantity"
+
+      true ->
+        unit = normalize_unit(unit)
+
+        %__MODULE__{
+          value: value,
+          unit: unit
+        }
+    end
   end
 
   @doc """

--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -100,7 +100,10 @@ defmodule Quantity do
          {value, ""} <- Decimal.parse(value_string) do
       unit = parse_unit(unit_string)
 
-      {:ok, new(value, unit)}
+      case try_new(value, unit) do
+        {:ok, quantity} -> {:ok, quantity}
+        {:error, _reason} -> :error
+      end
     else
       _ -> :error
     end

--- a/lib/quantity.ex
+++ b/lib/quantity.ex
@@ -37,20 +37,9 @@ defmodule Quantity do
   """
   @spec new(Decimal.t(), unit) :: t
   def new(value, unit) do
-    cond do
-      Decimal.inf?(value) ->
-        raise ArgumentError, "Infinity not supported by Quantity"
-
-      Decimal.nan?(value) ->
-        raise ArgumentError, "NaN not supported by quantity"
-
-      true ->
-        unit = normalize_unit(unit)
-
-        %__MODULE__{
-          value: value,
-          unit: unit
-        }
+    case try_new(value, unit) do
+      {:ok, quantity} -> quantity
+      {:error, reason} -> raise ArgumentError, reason
     end
   end
 
@@ -63,6 +52,31 @@ defmodule Quantity do
     positive_base_value = Kernel.abs(base_value)
     value = Decimal.new(sign, positive_base_value, exponent)
     new(value, unit)
+  end
+
+  @doc """
+  Tries to create a new Quantity. If it fails because of infinity or NaN decimal, will return an error tuple.
+  This could be used instead of new/2 when creating a Quantity from user input or other thirdparty input.
+  """
+  @spec try_new(Decimal.t(), unit) :: {:ok, t()} | {:error, reason :: String.t()}
+  def try_new(value, unit) do
+    cond do
+      Decimal.inf?(value) ->
+        {:error, "Infinity not supported by Quantity"}
+
+      Decimal.nan?(value) ->
+        {:error, "NaN not supported by Quantity"}
+
+      true ->
+        unit = normalize_unit(unit)
+
+        quantity = %__MODULE__{
+          value: value,
+          unit: unit
+        }
+
+        {:ok, quantity}
+    end
   end
 
   @doc """

--- a/test/quantity_test.exs
+++ b/test/quantity_test.exs
@@ -50,4 +50,11 @@ defmodule QuantityTest do
   test "to_string for 1-unit" do
     assert Quantity.to_string(~Q[42]) == "42"
   end
+
+  test "for non-number decimals" do
+    ["inf", "-inf", "nan"]
+    |> Enum.each(fn not_number ->
+      catch_error(not_number |> Decimal.new() |> Quantity.new("unit"))
+    end)
+  end
 end

--- a/test/quantity_test.exs
+++ b/test/quantity_test.exs
@@ -33,6 +33,10 @@ defmodule QuantityTest do
     assert quantity.unit == {:div, 1, "unit"}
   end
 
+  test "parsing non-number decimal" do
+    assert Quantity.parse("inf bananas") == :error
+  end
+
   test "complex unit" do
     assert {:ok, quantity} = Quantity.parse("1 a*b*c/d*e*f")
     assert quantity.unit == {:div, {:mult, "a", {:mult, "b", "c"}}, {:mult, "d", {:mult, "e", "f"}}}

--- a/test/quantity_test.exs
+++ b/test/quantity_test.exs
@@ -57,4 +57,9 @@ defmodule QuantityTest do
       catch_error(not_number |> Decimal.new() |> Quantity.new("unit"))
     end)
   end
+
+  test "try_new" do
+    assert Quantity.try_new(~d[1], "banana") == {:ok, ~Q[1 banana]}
+    assert Quantity.try_new(~d[inf], "banana") == {:error, "Infinity not supported by Quantity"}
+  end
 end


### PR DESCRIPTION
This is a breaking change:

Quantity will now no longer accept decimal values of `~d[inf]`, `~d[-inf]` or `~d[nan]`.
These could easilty lead to errors and should probably never be used in a Quantity.