### PR TITLE
Bump 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,16 @@
 
 ## 1.0.2 2024-02-05
 
-* Update deps
 * Update Elixir to 1.16
-* Update Elixir to 1.15.7
+* Update Erlang to 26
 * Remove unnecessary readme paragraph
 * Improve CI otp/elixir matrix
-* Update Erlang to 26
-* update elixir 1.14.4 -> 1.14.5
-* update erlang 25.3.1 -> 25.3.2
 * update dialyxir 1.2.0 -> 1.3.0
 * update credo 1.6.7 -> 1.7.0
-* update ex_doc 0.29.1 -> 0.29.4
+* update ex_doc 0.29.0 -> 0.29.4
 * update earmark_parser 1.4.30 -> 1.4.32
 * update makeup_elixir 0.16.0 -> 0.16.1, nimble_parsec 1.2.3 -> 1.3.1
 * update decimal 2.0.0 -> 2.1.1
-* update erlang 25.2.1 -> 25.3.1
-* update elixir 1.14.3 -> 1.14.4
-* Update deps 20230221 (#79)
-* update elixir 1.14.1 -> 1.14.3
-* update erlang 25.1.2 -> 25.2.1
-* update ex_doc 0.29.0 -> 0.29.1
 
 ## 1.0.1 2022-11-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.0.2 2024-02-05
+
+* Update deps
+* Update Elixir to 1.16
+* Update Elixir to 1.15.7
+* Remove unnecessary readme paragraph
+* Improve CI otp/elixir matrix
+* Update Erlang to 26
+* update elixir 1.14.4 -> 1.14.5
+* update erlang 25.3.1 -> 25.3.2
+* update dialyxir 1.2.0 -> 1.3.0
+* update credo 1.6.7 -> 1.7.0
+* update ex_doc 0.29.1 -> 0.29.4
+* update earmark_parser 1.4.30 -> 1.4.32
+* update makeup_elixir 0.16.0 -> 0.16.1, nimble_parsec 1.2.3 -> 1.3.1
+* update decimal 2.0.0 -> 2.1.1
+* update erlang 25.2.1 -> 25.3.1
+* update elixir 1.14.3 -> 1.14.4
+* Update deps 20230221 (#79)
+* update elixir 1.14.1 -> 1.14.3
+* update erlang 25.1.2 -> 25.2.1
+* update ex_doc 0.29.0 -> 0.29.1
+
 ## 1.0.1 2022-11-01
 
 * update ex_doc 0.28.5 -> 0.29.0

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Quantity.MixProject do
   def project do
     [
       app: :quantity,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
I opened this version bump as PR because I am not sure about following things:
1. Does changelog look good? It contains only Erlang, Elixir and deps updates named differently for each separate deps update. Maybe we should have only 3 entries there? ("Update Erlang version to ...", "Update Elixir version to ....", "Update deps")
2. Shouldn't we release new version 1.0.2 to hex.pm? (https://hex.pm/packages/quantity)