### PR TITLE
feat(scripts): enhance tag_new_version

### DIFF
--- a/scripts/tag_new_version.sh
+++ b/scripts/tag_new_version.sh
@@ -1,8 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-changelog=`git log --graph --pretty=format:'%s%d' | sed -e '/tag: /,$ d'`
+# find the appropriate version of sed to use.
+# on BSDs, gsed is typically the gnu version of sed, typically installed via homebrew
+SED=$(command -v gsed || command -v sed || exit 1)
+
+changelog=`git log --no-show-signature --graph --pretty=format:'%s%d' | "$SED" -e '/tag: /Q'`
 last_version=`git tag | grep -E "^[0-9]+\.[0-9]+\.[0-9]+" | sort --version-sort | tail -1`
 
 # Clean up changelog
@@ -10,28 +14,35 @@ changelog_file=.tag_new_version_changelog
 echo -e "# Clean up the changelog:\n" > $changelog_file
 echo "$changelog" >> $changelog_file
 $EDITOR $changelog_file
-changelog=`cat $changelog_file | sed -e '/^#/ d'`
+changelog=`cat $changelog_file | "$SED" -e '/^#/ d'`
 rm $changelog_file
 
 # Input version
 version_file=.tag_new_version_version
 echo -e "$last_version\n\n# Type the version of the new release" > $version_file
 echo "# Last version: $last_version" >> $version_file
-echo "$changelog" | sed -e 's/^/# /g' >> $version_file
+echo "$changelog" | "$SED" -e 's/^/# /g' >> $version_file
 $EDITOR $version_file
-version=`cat $version_file | sed -e '/^#/ d' | xargs`
+version=`cat $version_file | "$SED" -e '/^#/ d' | xargs`
 rm $version_file
 
 # Add headline to new changelog
 date=`date +%Y-%m-%d`
-sed -i -e "2 a ## $version $date\n" CHANGELOG.md
+"$SED" -i -e "2 a ## $version $date\n" CHANGELOG.md
 
 # Append new changelog
 escaped_changelog=${changelog//$'\n'/\\$'\n'}
-sed -i -e "4 a $escaped_changelog\n" CHANGELOG.md
+"$SED" -i -e "4 a $escaped_changelog\n" CHANGELOG.md
 
 # Update version in mix.exs
-sed -i -e "s/$last_version/$version/" mix.exs
+"$SED" -i -e "s/$last_version/$version/" mix.exs
+
+# Check if new version was set
+# useful when there is discrepancy between mix.ex and actual git tags
+if ! grep -q "version: \"$version\"" mix.exs; then
+  echo "New version was not set in mix.exs file!"
+  exit 1
+fi
 
 # Stage changes
 files="CHANGELOG.md mix.exs"


### PR DESCRIPTION
- Use env to specify bash interpreter
- Determine correct sed version based on environment
- Add safeguards to ensure version updates in mix.exs